### PR TITLE
Added firstline language detection for WolframScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "vscode": "^1.14.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "keywords": [
         "mathematica",
@@ -32,6 +32,7 @@
         "languages": [{
             "id": "wolfram",
             "aliases": ["Wolfram Language", "wolfram", "Mathematica", "mathematica", "wolframscript"],
+            "firstLine": "^#!\\s*/.*(?:wolframscript)\\b",
             "extensions": [".m",".nb",".wl",".wls"],
             "configuration": "./wolfram-configuration.json"
         }],


### PR DESCRIPTION
So that files starting with `#!/usr/bin/env wolframscript` are detected automatically

Also fixed a minor issue with standard package.json categories, should be "Programming Languages" as the category.